### PR TITLE
Fix Blank Canvas Issue by Setting Tkinter Fill Colors

### DIFF
--- a/AVL_tree.py
+++ b/AVL_tree.py
@@ -286,7 +286,7 @@ class Node:
         node_radius = min(node_radius, 10)
         window = Tk()
         window.title("Binary Tree")  # Set a title
-        canvas = Canvas(window, width=window_width + 100, height=window_height + 100, bg="white")
+        canvas = Canvas(window, width=window_width + 100, height=window_height + 100, bg="black")
         canvas.pack()
         window_height = int((window_height - 2 * tree_height * node_radius) / tree_height)
         lines_to_draw = self.get_lines(50 + window_width / 2, 50 + node_radius, window_width / 2, window_height)
@@ -295,7 +295,7 @@ class Node:
             y1 = line_to_draw[1]
             x2 = line_to_draw[2]
             y2 = line_to_draw[3]
-            canvas.create_line(x1, y1, x2, y2)
+            canvas.create_line(x1, y1, x2, y2, fill="white")
         nodes_to_draw = self.get_coords(50 + window_width / 2, 50 + node_radius, window_width / 2, window_height)
         for node_to_draw in nodes_to_draw:
             x = node_to_draw[0]
@@ -303,7 +303,7 @@ class Node:
             text = node_to_draw[2]
             if node_radius >= 10:
                 canvas.create_oval(x - node_radius, y - node_radius, x + node_radius, y + node_radius, fill="white")
-            canvas.create_text(x, y, text=text)
+            canvas.create_text(x, y, text=text, fill="black")
 
         window.mainloop()
 


### PR DESCRIPTION
Issue:
Elements drawn on the white canvas are also white, so what appears to be an empty white window is displayed. This could be due to a change in the default colors used by Tkinter, or inconsistency in colors across platforms.

Fix:
Manually set the Tkinter fill colors so that defaults aren't used.

Environment:
MacOS 15.2
Python 3.13.1
Tkinter 9.0

Before:
<img width="986" alt="Screenshot 2025-02-04 at 09 18 03" src="https://github.com/user-attachments/assets/e11c247d-84bb-42c9-a3f7-4b37a8235c0a" />

After:
<img width="986" alt="Screenshot 2025-02-04 at 09 17 50" src="https://github.com/user-attachments/assets/6bcb91b5-133c-4bc3-9707-8a5e99ac47af" />

